### PR TITLE
Add MeisExtendedCameraModel with k3 radial distortion

### DIFF
--- a/colmap_cameras/models/__init__.py
+++ b/colmap_cameras/models/__init__.py
@@ -13,5 +13,6 @@ from .division_model import DivisionModel
 from .polynomial_division_model import PolynomialDivisionModel
 from .unified_camera_model import UnifiedCameraModel
 from .meis_camera_model import MeisCameraModel
+from .meis_extended_camera_model import MeisExtendedCameraModel
 from .woodscape import WoodScape
 from .equirectangular import Equirectangular

--- a/colmap_cameras/models/colmap_models_list.py
+++ b/colmap_cameras/models/colmap_models_list.py
@@ -21,6 +21,7 @@ colmap_models = [
     PolynomialDivisionModel,
     UnifiedCameraModel,
     MeisCameraModel,
+    MeisExtendedCameraModel,
     WoodScape,
     Equirectangular
 ]

--- a/colmap_cameras/models/meis_extended_camera_model.py
+++ b/colmap_cameras/models/meis_extended_camera_model.py
@@ -1,0 +1,113 @@
+"""
+2024 Daniil Sinitsyn
+
+Colmap camera models implemented in PyTorch
+"""
+from ..base_model import BaseModel
+import torch
+from ..utils.iterative_undistortion import IterativeUndistortion
+
+class MeisExtendedCameraModel(BaseModel):
+    """
+    Extended Unified Camera Model from Mei's paper with k3 radial distortion.
+    Parameters: fx, fy, cx, cy, alpha, k1, k2, k3, p1, p2
+    """
+    model_name = 'MEIS_EXTENDED_CAMERA_MODEL'
+    num_focal_params = 2
+    num_pp_params = 2
+    num_extra_params = 1 + 5
+
+    def __init__(self, x, image_shape):
+        super().__init__(x, image_shape)
+
+    @staticmethod
+    def default_initialization(image_shape):
+        x = torch.zeros(10)
+        x[:2] = torch.tensor([image_shape[0], image_shape[1]]) / 2
+        x[2:4] = x[:2]
+        return MeisExtendedCameraModel(x, image_shape)
+
+    def map(self, points3d):
+        d = torch.linalg.norm(points3d, dim=-1)
+        valid = d[..., 2] + self[4] * d > self.EPSILON
+        uv = points3d[:, :2] / (points3d[..., 2] + self[4] * d)[..., None]
+
+        uv[valid] = self._distortion(uv[valid])
+
+        return uv * self[:2].reshape(1, 2) + self[2:4].reshape(1, 2), valid
+
+    def unmap(self, points2d):
+        uv0 = (points2d - self[2:4].reshape(1, 2)) / self[:2].reshape(1, 2)
+
+        uv = IterativeUndistortion.apply(self[5:], uv0, self, self.ROOT_FINDING_MAX_ITERATIONS)
+
+        r2 = uv[:, 0] * uv[:, 0] + uv[:, 1] * uv[:, 1]
+        b = (self[4] + (1 + (1 - self[4] * self[4]) * r2).sqrt()) / (1 + r2)
+
+        uv = uv * (b / (b - self[4]))[..., None]
+        uv[b - self[4] < self.EPSILON] = 0.0
+
+        return torch.cat((uv, torch.ones_like(uv[:, :1])), dim=-1)
+
+
+    def _distortion(self, pts2d):
+        u2 = pts2d[:, 0] ** 2
+        v2 = pts2d[:, 1] ** 2
+        uv = pts2d[:, 0] * pts2d[:, 1]
+        r2 = u2 + v2
+        radial = (self[5] + (self[6] + self[7] * r2) * r2) * r2
+
+        tg_u = 2 * self[8] * uv + self[9] * (r2 + 2 * u2)
+        tg_v = 2 * self[9] * uv + self[8] * (r2 + 2 * v2)
+
+        new_pts2d = pts2d * (1 + radial[:, None])
+        new_pts2d += torch.stack((tg_u, tg_v), dim=-1)
+
+        return new_pts2d
+
+    def _d_distortion_d_params(self, pts2d):
+        u2 = pts2d[:, 0] ** 2
+        v2 = pts2d[:, 1] ** 2
+        uv = pts2d[:, 0] * pts2d[:, 1]
+        r2 = u2 + v2
+
+        res = torch.zeros(pts2d.shape[0], 2, 5).to(pts2d)
+        res[:, 0, 0] = pts2d[:, 0] * r2
+        res[:, 1, 0] = pts2d[:, 1] * r2
+        res[:, 0, 1] = res[:, 0, 0] * r2
+        res[:, 1, 1] = res[:, 1, 0] * r2
+        res[:, 0, 2] = res[:, 0, 1] * r2
+        res[:, 1, 2] = res[:, 1, 1] * r2
+
+        res[:, 0, 3] = 2 * uv
+        res[:, 1, 3] = r2 + 2 * v2
+        res[:, 0, 4] = r2 + 2 * u2
+        res[:, 1, 4] = res[:, 0, 3]
+
+        return res
+
+
+    def _d_distortion_d_pts2d(self, pts2d):
+        u2 = pts2d[:, 0] ** 2
+        v2 = pts2d[:, 1] ** 2
+        r2 = u2 + v2
+
+        res = torch.eye(2).to(pts2d).unsqueeze(0).repeat(pts2d.shape[0], 1, 1)
+
+        radial = (self[5] + (self[6] + self[7] * r2) * r2) * r2
+        res *= (1 + radial[:, None])[:, :, None]
+
+        dv = (2 * self[5] + (4 * self[6] + 6 * self[7] * r2) * r2) * pts2d[:, 1]
+        du = (2 * self[5] + (4 * self[6] + 6 * self[7] * r2) * r2) * pts2d[:, 0]
+
+        res[:,0,0] += du * pts2d[:, 0]
+        res[:,1,1] += dv * pts2d[:, 1]
+        res[:,0,1] += dv * pts2d[:, 0]
+        res[:,1,0] += du * pts2d[:, 1]
+
+        res[:,0,0] += 2 * self[8] * pts2d[:, 1] + 6 * self[9] * pts2d[:, 0]
+        res[:,1,1] += 2 * self[9] * pts2d[:, 0] + 6 * self[8] * pts2d[:, 1]
+        res[:,0,1] += 2 * self[8] * pts2d[:, 0] + 2 * self[9] * pts2d[:, 1]
+        res[:,1,0] += 2 * self[9] * pts2d[:, 1] + 2 * self[8] * pts2d[:, 0]
+
+        return res

--- a/tests/meis_extended_camera_model.py
+++ b/tests/meis_extended_camera_model.py
@@ -1,0 +1,73 @@
+"""
+2024 Daniil Sinitsyn
+
+Colmap camera models implemented in PyTorch
+"""
+import unittest
+import torch
+from colmap_cameras.models import MeisExtendedCameraModel, MeisCameraModel
+from .base import TestBase
+
+def get_model(img_size, extra):
+    x = torch.zeros(10)
+    x[:2] = img_size * 1.4
+    x[2:4] = img_size / 2
+    x[4:] = extra
+    return MeisExtendedCameraModel(x, img_size)
+
+class TestMeisExtendedCameraModel(TestBase):
+    def setUp(self):
+        img_size = torch.tensor([100, 100])
+        self.models = []
+        self.models.append(get_model(img_size, torch.tensor([0.0, 0.0, 0.0, 0.0, 0.0, 0.0])))
+        self.models.append(get_model(img_size, torch.tensor([2.4, 0.016, 1.65, 0.0, 0.00042, 0.00042])))
+        self.models.append(get_model(img_size, torch.tensor([2.4, 0.016, 1.65, 0.01, 0.00042, 0.00042])))
+
+        self.model1 = get_model(img_size, torch.tensor([2.4, 0.016, 1.65, 0.01, 0.00042, 0.00042]))
+        self.model2 = get_model(img_size, torch.tensor([2.3, 0.015, 1.6, 0.008, 0.00042, 0.00042]))
+        self.iters = 30
+
+class TestMeisExtendedK3Zero(unittest.TestCase):
+    def test_k3_zero_matches_base_model(self):
+        """Extended model with k3=0 should match the base MeisCameraModel"""
+        img_size = torch.tensor([100, 100])
+
+        base_x = torch.zeros(9)
+        base_x[:2] = img_size * 1.4
+        base_x[2:4] = img_size / 2
+        base_x[4:] = torch.tensor([2.4, 0.016, 1.65, 0.00042, 0.00042])
+        base_model = MeisCameraModel(base_x, img_size)
+
+        ext_model = get_model(img_size, torch.tensor([2.4, 0.016, 1.65, 0.0, 0.00042, 0.00042]))
+
+        for u in torch.arange(-0.3, 0.3, 0.1):
+            for v in torch.arange(-0.3, 0.3, 0.1):
+                pts3d = torch.tensor([[u, v, 1.0], [u, v, 1.0], [u, v, 1.0]]).float()
+                pts2d_base, valid_base = base_model.map(pts3d)
+                pts2d_ext, valid_ext = ext_model.map(pts3d)
+                self.assertTrue(torch.allclose(pts2d_base, pts2d_ext, atol=1e-6))
+
+class TestMeisExtendedK3Effect(unittest.TestCase):
+    def test_k3_affects_distortion(self):
+        """Non-zero k3 should produce different distortion than k3=0"""
+        img_size = torch.tensor([100, 100])
+        model_no_k3 = get_model(img_size, torch.tensor([0.0, 0.016, 1.65, 0.0, 0.00042, 0.00042]))
+        model_with_k3 = get_model(img_size, torch.tensor([0.0, 0.016, 1.65, 0.5, 0.00042, 0.00042]))
+
+        pts2d = torch.tensor([[0.5, 0.5], [0.3, 0.4], [-0.2, 0.3]]).float()
+        d_no_k3 = model_no_k3._distortion(pts2d)
+        d_with_k3 = model_with_k3._distortion(pts2d)
+
+        self.assertFalse(torch.allclose(d_no_k3, d_with_k3, atol=1e-6))
+
+    def test_colmap_string_roundtrip(self):
+        """to_colmap should produce a parseable string with correct param count"""
+        img_size = torch.tensor([100, 100])
+        model = get_model(img_size, torch.tensor([2.4, 0.016, 1.65, 0.3, 0.00042, 0.00042]))
+        colmap_str = model.to_colmap()
+        parts = colmap_str.split()
+        self.assertEqual(parts[0], 'MEIS_EXTENDED_CAMERA_MODEL')
+        self.assertEqual(len(parts), 1 + 2 + 10)  # name + image_shape + params
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -19,6 +19,7 @@ from .division_model import TestDivisionModel
 from .polynomial_division_model import TestPolynomialDivisionModel
 from .unified_camera_model import TestUnifiedCameraModel
 from .meis_camera_model import TestMeisCameraModel
+from .meis_extended_camera_model import TestMeisExtendedCameraModel
 from .equirectangular import TestEquirectangular
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
  - Add new MeisExtendedCameraModel extending the MEI model with a k3 radial distortion parameter
  (r⁶ term)
  - Parameters: fx, fy, cx, cy, alpha, k1, k2, k3, p1, p2 (10 params total)
  - Original MeisCameraModel is unchanged

  ## Test plan
  - [x] Standard map/unmap round-trip tests pass
  - [x] k3=0 produces results identical to the base MeisCameraModel
  - [x] Non-zero k3 produces measurably different distortion
  - [x] COLMAP string serialization round-trip works
  - [x] Full test suite passes (no regressions)